### PR TITLE
Block navigation shorts button in horizontally collapsed view

### DIFF
--- a/removeShortsDom.js
+++ b/removeShortsDom.js
@@ -11,7 +11,8 @@ browser.storage.local
         display: none !important;
       }
     
-      ytd-mini-guide-entry-renderer[aria-label=Shorts] {
+      ytd-mini-guide-entry-renderer[aria-label="Shorts"],
+      ytd-mini-guide-entry-renderer:has(a[href="/shorts/"]) {
         display: none !important;
       }`)
       );


### PR DESCRIPTION
Hi,

I noticed that when using browsers with vertical tabs (such as Zen, or Arc), the YouTube UI still displays the Shorts button in the navigation panel. To address this, I expanded the CSS rules to include `ytd-mini-guide-entry-renderer:has(a[href="/shorts/"])`, which ensures that any navigation item linking to the Shorts feed is caught.

Also, thank you for maintaining this extension, it’s been incredibly useful!

Before: 
<img width="1624" height="1061" src="https://github.com/user-attachments/assets/c6d9018c-5fc9-4aa0-befe-fecd08bbe7d5" />
After:
<img width="1624" height="1061" src="https://github.com/user-attachments/assets/08d337ac-516b-458f-82d5-e1e590a74843" />
